### PR TITLE
Specify the repository url in the written package.jsons

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,11 @@ function go(platform, arch, version, product, cb) {
         },
         files: [
             filename
-        ]
+        ],
+        repository: {
+            type: "git",
+            url: "https://github.com/aredridel/" + product + "-bin"
+        }
     };
 
     if (product == "iojs") {


### PR DESCRIPTION
`npm WARN package.json node-darwin-x64@0.12.2 No repository field.`

This prevents another warning when installing a generated package.