### PR TITLE
tell npm@2 to warn the end user when installing it

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.0.0",
+    "npm": ">2.0.0"
   },
   "dependencies": {
     "rimraf": "^3.0.0",


### PR DESCRIPTION
See [https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines)

does not change any code behavior but atleast `npm@2` will let know the user
to update npm