### PR TITLE
Fix package.json cpu for node-linux-ppc64le

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ async function buildArchPackage(os, cpu, version, pre) {
       "LICENSE",
     ],
     os: platform,
-    cpu: arch,
+    cpu: arch == 'ppc64le' ? 'ppc64' : arch,
   };
 
   debug("removing", dir);


### PR DESCRIPTION
Node.js defines `process.arch` as `ppc64` for both obsolete BE and current LE systems.  This currently prevents node-linux-ppc64le from being installable, e.g.:
```
$ npm i node-linux-ppc64le
npm ERR! code EBADPLATFORM
npm ERR! notsup Unsupported platform for node-linux-ppc64le@19.1.0: wanted {"os":"linux","arch":"ppc64le"} (current: {"os":"linux","arch":"ppc64"})
npm ERR! notsup Valid OS:    linux
npm ERR! notsup Valid Arch:  ppc64le
npm ERR! notsup Actual OS:   linux
npm ERR! notsup Actual Arch: ppc64
```

A combination of this (with a rebuild of all supported versions) and https://github.com/aredridel/node-bin-setup/pull/5 is needed to fix `npm install node` on Power LE.


